### PR TITLE
fix: correct EnvVarSource type in vvp model

### DIFF
--- a/api/v1beta2/vpdeployment_conversion_test.go
+++ b/api/v1beta2/vpdeployment_conversion_test.go
@@ -59,6 +59,16 @@ var _ = Describe("VpDeployment conversion", func() {
 								Kind:   "JAR",
 								JarURI: "https://jars.com/peanut-butter",
 							},
+							Kubernetes: &VpKubernetesOptions{
+								Pods: &VpPodSpec{
+									EnvVars: []core.EnvVar{
+										{
+											Name: "TEST_ENV",
+											Value: "TEST_VALUE",
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -93,6 +103,16 @@ var _ = Describe("VpDeployment conversion", func() {
 							Artifact: &v1beta1.VpArtifact{
 								Kind:   "JAR",
 								JarURI: "https://jars.com/peanut-butter",
+							},
+							Kubernetes: &v1beta1.VpKubernetesOptions{
+								Pods: &v1beta1.VpPodSpec{
+									EnvVars: []core.EnvVar{
+										{
+											Name: "TEST_ENV",
+											Value: "TEST_VALUE",
+										},
+									},
+								},
 							},
 						},
 					},
@@ -341,5 +361,7 @@ var _ = Describe("VpDeployment conversion", func() {
 		Expect(v2.Spec.Spec.MaxJobCreationAttempts).To(BeEquivalentTo(v2Clone.Spec.Spec.MaxJobCreationAttempts))
 		Expect(v2.Spec.Spec.Template.Metadata).To(BeEquivalentTo(v2Clone.Spec.Spec.Template.Metadata))
 		Expect(v2.Spec.Spec.Template.Spec).To(BeEquivalentTo(v2Clone.Spec.Spec.Template.Spec))
+		k8sSpec := v2.Spec.Spec.Template.Spec.Kubernetes
+		Expect(k8sSpec.Pods.EnvVars).To(BeEquivalentTo(v2Clone.Spec.Spec.Template.Spec.Kubernetes.Pods.EnvVars))
 	})
 })

--- a/api/v1beta2/vpdeploymenttarget_conversion_test.go
+++ b/api/v1beta2/vpdeploymenttarget_conversion_test.go
@@ -37,7 +37,11 @@ var _ = Describe("VpDeploymentTarget conversion", func() {
 			Value: pointer.StringPtr("gazelle"),
 		},
 	}
-	jsonPatchStr := "[{\"op\":\"add\",\"path\":\"/hello\",\"value\":\"gazelle\"}]"
+	jsonPatchStr := `[{
+		"op": "add",
+		"path": "/hello",
+		"value": "gazelle"
+	}]`
 
 	It("should convert to the hub", func() {
 		// [{"op":"add","path":"/hello","value":"gazelle"}]

--- a/api/v1beta2/vpdeploymenttarget_conversion_test.go
+++ b/api/v1beta2/vpdeploymenttarget_conversion_test.go
@@ -37,11 +37,7 @@ var _ = Describe("VpDeploymentTarget conversion", func() {
 			Value: pointer.StringPtr("gazelle"),
 		},
 	}
-	jsonPatchStr := `[{
-		"op": "add",
-		"path": "/hello",
-		"value": "gazelle"
-	}]`
+	jsonPatchStr := "[{\"op\":\"add\",\"path\":\"/hello\",\"value\":\"gazelle\"}]"
 
 	It("should convert to the hub", func() {
 		// [{"op":"add","path":"/hello","value":"gazelle"}]

--- a/pkg/vvp/appmanager-api/model_env_var.go
+++ b/pkg/vvp/appmanager-api/model_env_var.go
@@ -10,8 +10,10 @@
 
 package appmanagerapi
 
+import core "k8s.io/api/core/v1"
+
 type EnvVar struct {
 	Name      string    `json:"name,omitempty"`
 	Value     string    `json:"value,omitempty"`
-	ValueFrom *JsonNode `json:"valueFrom,omitempty"`
+	ValueFrom *core.EnvVarSource `json:"valueFrom,omitempty"`
 }


### PR DESCRIPTION
The autogenerated VVP client uses the incorrect `JsonNode` type. For the EnvVar model, the `core.EnvVarSource` should be used instead. 

Closes  #151